### PR TITLE
Change argument pattern check for Google colab

### DIFF
--- a/rename_files.py
+++ b/rename_files.py
@@ -6,7 +6,7 @@ import sys
 
 #引数があれば、引数からファイルパスを指定する
 folder_path = ""
-if 1 < len(sys.argv):
+if 2 == len(sys.argv):
   folder_path = sys.argv[1]
 else:
   # Prompt the user for the folder path


### PR DESCRIPTION
Google Colab環境では、Pythonのファイル名と引数が特殊な環境に置き換わってしまうようでした。

例:
`/usr/local/lib/python3.10/dist-packages/colab_kernel_launcher.py -f /root/.local/share/jupyter/runtime/kernel-c8cbb552-f905-4f23-9cb6-3233c1620ba3.json`

第一引数があればフォルダパスとして動作させていたコードにおいて、上の'-f'をフォルダパスとして扱ってしまうため、ReadMe.csvの読み込みに失敗してしまうようでした。

解決方法としては引数処理を正しくする(--folder_path ...みたいに指定する)のがいいと思いますが、実装も大変で、使いこなしも面倒です。あるいは、Google Colabの実行環境をチェックするのがよさそうですが、何か変更があった際に追従していく必要があります。

正しい実装ではありませんが、実行ファイルを含む引数が2個だったら二つ目をフォルダパスとして扱うようにしました。Google Colabでは実行ファイルを含む引数が3つあるので、この✅に該当しなくなります。※ただしGoogle Colabではフォルダパスを引数として与えられないデメリットもあります